### PR TITLE
jfuica. hooks improvements :

### DIFF
--- a/src/GIT.py
+++ b/src/GIT.py
@@ -288,3 +288,39 @@ class GIT:
         if p.returncode != 0:
 
             raise GITError(self._("CC_update_failed") + str(err))
+
+    def last_commit_labels(self, gitpath):
+        """
+        Executes git describe command in the HEAD to return labels
+
+        Raises GITError exception when GIT command fails.
+
+        """
+
+        labels_list = []
+
+        gitenv = self._set_env(gitpath)
+
+        try:
+
+            p = subprocess.Popen(["git tag --points-at HEAD"],
+                              shell=True,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              env=gitenv)
+            pathlist, err = p.communicate()
+
+        except:
+
+            raise GITError(self._("GIT_labels_failed") + str(sys.exc_info()))
+
+        if p.returncode == 0:
+
+            labels_list = pathlist.splitlines()
+
+        else:
+
+            raise GITError("git describe" + self._("command_failed") +
+                          str(err))
+
+        return labels_list

--- a/src/HooksConfig.py
+++ b/src/HooksConfig.py
@@ -172,3 +172,15 @@ class HooksConfig(object):
             branches = [x.strip() for x in branches]
 
         return branches
+
+    def get_vobs(self):
+        """
+        Return the configured CC vobs
+
+        """
+        vobs = []
+
+        vobs = self._config.get("cc_view", "vobs").split(' ')
+
+        return vobs
+

--- a/src/Log.py
+++ b/src/Log.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""
+@summary: This module provides logging methods.
+
+"""
+
+import logging
+import logging.handlers
+
+LOG_FILENAME = "/tmp/Git2CC.log"
+
+LOG_FORMATTER = '%(asctime)s %(levelname)-8s %(message)s'
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+# define a Handler which writes INFO messages or higher to the sys.stderr
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter(LOG_FORMATTER)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+# create error file handler and set level to error
+
+handler = logging.handlers.RotatingFileHandler(LOG_FILENAME, maxBytes=1000000, backupCount=5)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter(LOG_FORMATTER)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+def debug (comment):
+    """
+    Logs a debug trace.
+
+    """
+    logger.debug(comment)
+
+
+def error (comment):
+    """
+    Logs a debug trace.
+
+    """
+    logger.error(comment)
+
+def info (comment):
+    """
+    Logs a debug trace.
+
+    """
+    logger.info(comment)
+
+def warning (comment):
+    """
+    Logs a debug trace.
+
+    """
+    logger.warning(comment)
+
+def critical (comment):
+    """
+    Logs a debug trace.
+
+    """
+    logger.critical(comment)
+
+
+    

--- a/src/hooks_config/bridge.cfg
+++ b/src/hooks_config/bridge.cfg
@@ -2,6 +2,8 @@
 
 path: /path/to/cc_view
 
+vobs:
+
 [cc_config]
 
 cleartool_path: /usr/atria/bin/cleartool

--- a/src/hooks_config/bridge.cfg
+++ b/src/hooks_config/bridge.cfg
@@ -1,6 +1,6 @@
 [cc_view]
 
-path: /path/to/cc_view
+path: ./
 
 vobs:
 


### PR DESCRIPTION
1.- A list of needed checkouts to Add or delete objects has been used to prevent a ct lsco -r -cvi that takes too much time. Now, the Git-CC synchronization is faster.

2.- A key in the comments or the use of the last commit git label is used to label CC elements. Configure it with git push --follow-tags or git config --global push.followTags true

3.- Git to CC synchronization errors fixed.

4.- A logging mechanish to log and detects errors has been created, and many traces added.
Note : The First time the file is created (chmod a+rw is needed to allow several users to write on in).

5.- Configure the list of vobs in the bridge.cfg. If no vob is configured all the directories in the configured view is used to search checkouts.
